### PR TITLE
changed pdfminer requirement to point to source

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ requests==0.11.1
 git+git://github.com/fgregg/legistar-scrape#egg=legistar-scrape
 BeautifulSoup
 BeautifulSoup4
-pdfminer
+https://pypi.python.org/packages/source/p/pdfminer/pdfminer-20110515.tar.gz#md5=f3905f801ed469900d9e5af959c7631a
 slate
 git+https://github.com/abielr/mechanize.git#egg=mechanize
 


### PR DESCRIPTION
The install of pdfminer fails on Ubuntu/possibly other Linux systems because there's no pre-compiled distribution, so this was updated to point to source.
