### PR TITLE
Fix django-haystack requirements.txt git reference

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ markdown
 # ====================
 # Search
 # ====================
-git+git://github.com/toastdriven/django-haystack.git#egg=django-haystack==2.0.0-beta
+git+git://github.com/toastdriven/django-haystack.git@v2.0.0#egg=django-haystack==2.0.0
 
 # Using whoosh as the haystack (search) backend for now, for simplicity (it's
 # pure Python).  Good for local or development deployments.


### PR DESCRIPTION
This changes `requirements.txt` to pin the django-haystack package to the `v2.0.0` tag rather than depending on `django_haystack/master` to be at version 2.0.0-beta (it's at 2.1.1-dev right now).

I'm not a Python developer, but we were trying to get Councilmatic running at the @openlexington NDoCH today and `pip` was dying when the checked-out version (2.1.1-dev) didn't match the requirement (2.0.0-beta). I'm new to Councilmatic and haven't gotten the whole thing up and running yet, so I don't know if the move from the beta to the release causes any other problems.
