### PR TITLE
Add Legistar client links to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Copy the file *councilmatic/local_settings.py.template* to
 file.  By default, it is set up to scrape from Philadelphia's legislation
 system.
 
+A list of Legistar client URLs can be viewed [here](https://docs.google.com/spreadsheets/d/1IwNLFKHQ4RX9NyCRW8hM2514KiWW0bRmp4O7sJhdEz4/edit#gid=0).
 
 ### Database
 


### PR DESCRIPTION
I am working on replicating this project for the [OpenImpact replication marathon](http://blog.datalook.io/openimpact-councilmatic/) and thought it would be useful to add a Legistar client list to the README.

Covers:
- Add a list of [Legistar client links](https://docs.google.com/spreadsheets/d/1IwNLFKHQ4RX9NyCRW8hM2514KiWW0bRmp4O7sJhdEz4/edit#gid=0) to the README

Notes:
- Links were confirmed active as of July 30, 2015.
- The google doc is public and editable by anyone who has the link. If preferred, I can link to a gist or a view-only document.

Data sources:
- [Legistar client list](https://docs.google.com/spreadsheets/d/1_hbv-nbLI_Tc4pD297A59HDmu7ROQGPs0wfolYO_Vg0/edit#gid=0) from [Legistar-people](https://github.com/datamade/legistar-people/blob/master/settings.py.example)
- [Google Maps](https://www.google.com/maps/d/u/0/viewer?mid=zsKpLFizO3IE.k7sTYgExfE7U&hl=en_US)
